### PR TITLE
DI-6554: Added Sonar Scanner to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .coverage
 dev
 .DS_Store
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ install:
   - pipenv install --dev
 script:
   - pipenv run python -m pytest --cov=ids_validator --cov-branch --cov-report xml
-  - ls -la 
   - sed -i "s;$(pwd);/usr/src;g" coverage.xml
   - docker run -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli -Dsonar.projectKey=ts-ids-validator -Dsonar.login="$SONAR_TOKEN" -Dsonar.host.url="$SONAR_HOST"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ install:
   - pipenv install --dev
 script:
   - pipenv run python -m pytest --cov=ids_validator --cov-branch --cov-report xml
+  - ls -la 
   - sed -i "s;$(pwd);/usr/src;g" coverage.xml
   - docker run -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli -Dsonar.projectKey=ts-ids-validator -Dsonar.login="$SONAR_TOKEN" -Dsonar.host.url="$SONAR_HOST"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ install:
   - pip install pipenv
   - pipenv install --dev
 script:
-  - pipenv run python -m pytest --cov=ids_validator --cov-branch
+  - pipenv run python -m pytest --cov=ids_validator --cov-branch --cov-report xml
+  - sed -i "s;$(pwd);/usr/src;g" coverage.xml
+  - docker run -v "$(pwd):/usr/src" sonarsource/sonar-scanner-cli -Dsonar.projectKey=ts-ids-validator -Dsonar.login="$SONAR_TOKEN" -Dsonar.host.url="$SONAR_HOST"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectName=ts-ids-validator
+sonar.projectVersion=1.0-SNAPSHOT
+
+# =====================================================
+#   Properties that will be shared amongst all modules
+# =====================================================
+
+# SQ standard properties
+sonar.sources=ids_validator/
+sonar.tests=__tests__/unit
+
+# Properties specific to language plugins:
+sonar.python.coverage.reportPaths=coverage.xml
+
+# Specify python version
+sonar.python.version=3
+
+sonar.projectKey=ts-ids-validator
+


### PR DESCRIPTION
In this PR, I've added the Sonar Scanner to the repository so that we can send the coverage for the unit tests to SonarQube: 
http://sonarqube.api-testing.tetrascience.com/dashboard?id=ts-ids-validator